### PR TITLE
Fix import for Django 2

### DIFF
--- a/dajaxice/templatetags/dajaxice_templatetags.py
+++ b/dajaxice/templatetags/dajaxice_templatetags.py
@@ -4,7 +4,10 @@ from django import template
 from django.middleware.csrf import get_token
 from django.conf import settings
 from django.core.files.storage import get_storage_class
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
 from django.utils.safestring import mark_safe
 from dajaxice.core import dajaxice_config
 


### PR DESCRIPTION
django.core.urlresolvers module is now at django.urls, see
https://docs.djangoproject.com/en/2.2/releases/1.10/#id3